### PR TITLE
remove extraneous lookup

### DIFF
--- a/annotate.py
+++ b/annotate.py
@@ -111,7 +111,7 @@ def func_annotate_reg(module_name, function_name, instruction, function):
                 else: 
                     reg=params[i].src
                     try:
-                        address=mlil[mlil.get_ssa_var_definition(reg)].address
+                        address=mlil.get_ssa_var_definition(reg).address
                         offsets.append(address)
                     except:
                         pass
@@ -134,7 +134,7 @@ def func_annotate_reg(module_name, function_name, instruction, function):
                     else: 
                         reg=params[i].src
                         try:
-                            address=mlil[mlil.get_ssa_var_definition(reg)].address
+                            address=mlil.get_ssa_var_definition(reg).address
                             offsets.append(address)
                         except:
                             pass


### PR DESCRIPTION
We cleaned up the API to remove this extra lookup post BN builds 1616 and are issuing PRs just to let people know (though the old way will still work we do not recommend using it)