### PR TITLE
Fix issue with binary ninja 1.3

### DIFF
--- a/annotate.py
+++ b/annotate.py
@@ -69,6 +69,10 @@ def do_comment(function_arg,stack_args,function):
             stack_instruction = stack_args.next()
         else:
             stack_instruction = next(stack_args)
+
+        if stack_instruction is None:
+            return False
+
         function.set_comment(stack_instruction.address, function_arg)
         return True
     except StopIteration:


### PR DESCRIPTION
There was an issue with annotator (when installed via Plugin Manager on latest Binary Ninja), where next(stack_args) could return None, which would cause an exception to be raised that wasn't properly caught (and would stop annotation of the view at that point). This is a bandaid fix for that issue but seems to work in every case I've tried it in.